### PR TITLE
Minor changes for compatibility with Python 3.x

### DIFF
--- a/ocrodeg/__init__.py
+++ b/ocrodeg/__init__.py
@@ -1,1 +1,2 @@
-from degrade import *  # noqa
+# from degrade import *  # noqa
+from .degrade import *  # noqa

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,6 @@ from __future__ import print_function
 import sys
 from distutils.core import setup  # , Extension, Command
 
-assert sys.version_info[0] == 2 and sys.version_info[1] >= 7,\
-    "requires Python version 2.7 or later, but not Python 3.x"
-
 
 scripts = """
 """.split()


### PR DESCRIPTION
Minor changes to make the code compatible with Python 3.x.
Replaced 'range' arguments with 'limits' in order to ensure that the range keyword is not masked.