### PR TITLE
.gitignore byte-compiled and packaging files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.egg-info/


### PR DESCRIPTION
Installing the package generated byte-compiled (`__pycache__`) files and packaging files (`*.egg-info`). Ignore them in git.

Cf. https://github.com/github/gitignore/blob/master/Python.gitignore